### PR TITLE
WIP: Add CUDA support (proposal)

### DIFF
--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -43,6 +43,16 @@ conda update --yes --all
 conda install --yes conda-build==1.18.2
 conda info
 
+# Install CUDA support in the docker container.
+export CUDA_RPM_VERSION="7.5-18"
+export CUDA_RPM_MD5="01fd3415b197f9ddc4e58f5a4f2a9af6"
+curl "http://developer.download.nvidia.com/compute/cuda/repos/rhel6/x86_64/cuda-repo-rhel6-${CUDA_RPM_VERSION}.x86_64.rpm" > cuda.rpm
+md5sum cuda.rpm | grep "${CUDA_RPM_MD5}"
+yum install -y cuda.rpm
+yum clean all
+yum install -y cuda
+rm cuda.rpm
+
 # Embarking on 1 case(s).
     set -x
     export CONDA_PY=27

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,7 @@ mkdir build
 cd build
 
 # Configure, build, test, and install.
-cmake -DCPU_ONLY=1 -DBLAS="open" -DCMAKE_INSTALL_PREFIX="${PREFIX}" ..
+cmake -DBLAS="open" -DCMAKE_INSTALL_PREFIX="${PREFIX}" ..
 make
 make runtest
 make install


### PR DESCRIPTION
**PLEASE DO NOT MERGE!**

This PR attempts to build Caffe with CUDA support in addition to regular CPU support. It is far from done and will likely be broken up into a CUDA package that Caffe can then build against. Also, it does not currently contain cuDNN. The later requires registration for download. This may require some discussion with NVIDA about the best way for us to package these CUDA components and ship them. Most libraries appear to be ok by the EULA (though IANAL). However, it appears only one header is allowed. I don't know if this presents a problem for building against the libraries or not. Hopefully, this will help the discussion in this issue ( https://github.com/conda-forge/conda-forge.github.io/issues/63 ) proceed by looking at a real world example.
