### PR TITLE
MNT: Re-render the feedstock (Pt. 2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,24 @@ env:
     - secure: "jFPmeNtlHLjcQ+oVPzD/SUxPZlgSL7fbcSrc0r9VVXjdjyq8ycEAtMzwo29GGn0qIfpbmY/WTuDOZzKqISnXlp7sEluuqq9mkeQhUKf1H7eFmimvqkoA0bpONNTx+8sIqEWVBNqItLf56KrETBtpE2OsVUQncldmtY8VahQqAv3VMkqDowOTL9cqxjJpX50+nksj8w2yrhUBBb52A4ftoK618ajjfZb2jwDr9YA3AzMR2xv5uppJFb6tfhQQpjJ98QH5ujY0QnR7brjZr1bTvufARYgLPH5ubwSdWeghBm9ZnU+TjMYxOwpVtHKd9625rrwRfXfqxWQGapFNCYf46R/0gu2RMVVizZL1mi1g3CARSNKk3ZM+YVmO6j2pereqK1FfC0MGjIiPiRWouaFdZs9CVFxNVCPt4tRKqK1OPDzNivcGvi3wSHMdRyV1EYWjMoz6huV1z0siK5WKnBmYlDid1XpvFq3Cy9pOyqK8pbKqtjMmGMW3dao/l5BnTLWUCGFPBFQtb50HrqbyAjbfuoohU+cZYDYoZ5Bqxs9bMvuXLRQI7rllwuz0IY6yYuFrhrNnEMvbjf1/XVDPhDzB7y+jgTF5Vac1qpEwQCSfRxEjiUJPj1HGa/t4PI70mfPBrmnEAlGMdkbVVE7iICk1RMdR+yoYtNigOAkeCMujdVA="
 
 
-before install:
+before_install:
+    # Remove homebrew.
     - brew remove --force $(brew list)
+    - brew cleanup -s
+    - rm -rf $(brew --cache)
 
 install:
     - |
       MINICONDA_URL="http://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      wget "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
+      conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: http://caffe.berkeleyvision.org/
 
 Package license: BSD 2-Clause
 
-Feedstock license: BSD
+Feedstock license: BSD 3-Clause
 
 Summary: A deep learning framework made with expression, speed, and modularity in mind.
 
@@ -69,6 +69,7 @@ Terminology
 
 Current build status
 ====================
+
 Linux: [![Circle CI](https://circleci.com/gh/conda-forge/caffe-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/caffe-feedstock)
 OSX: [![TravisCI](https://travis-ci.org/conda-forge/caffe-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/caffe-feedstock) 
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/caffe-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/caffe-feedstock/branch/master)

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -20,7 +20,7 @@ channels:
 conda-build:
  root-dir: /feedstock_root/build_artefacts
 
-show_channel_urls: True
+show_channel_urls: true
 
 CONDARC
 )
@@ -29,7 +29,7 @@ cat << EOF | docker run -i \
                         -v ${RECIPE_ROOT}:/recipe_root \
                         -v ${FEEDSTOCK_ROOT}:/feedstock_root \
                         -a stdin -a stdout -a stderr \
-                        pelson/obvious-ci:latest_x64 \
+                        condaforge/linux-anvil \
                         bash || exit $?
 
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
@@ -40,7 +40,7 @@ echo "$config" > ~/.condarc
 conda clean --lock
 
 conda update --yes --all
-conda install --yes conda-build==1.18.2
+conda install --yes conda-build
 conda info
 
 # Embarking on 1 case(s).

--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,7 @@ dependencies:
   # Note, we used to use the naive caching of docker images, but found that it was quicker
   # just to pull each time. #rollondockercaching
   override:
-    - docker pull pelson/obvious-ci:latest_x64
-#    - docker pull pelson/conda32_obvious_ci
+    - docker pull condaforge/linux-anvil
 
 test:
   override:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,6 +5,11 @@ mkdir build
 cd build
 
 # Configure, build, test, and install.
+if [ "$(uname)" == "Linux" ];
+then
+    # Stop Boost from using libquadmath.
+    export CXXFLAGS="${CXXFLAGS} -DBOOST_MATH_DISABLE_FLOAT128"
+fi
 cmake -DCPU_ONLY=1 -DBLAS="open" -DCMAKE_INSTALL_PREFIX="${PREFIX}" ..
 make
 make runtest


### PR DESCRIPTION
Builds on this PR ( https://github.com/conda-forge/caffe-feedstock/pull/4 ). Fixes it so that Boost doesn't try to look for `libquadmath` as we don't include it. Inspired by this Boost ticket ( https://svn.boost.org/trac/boost/ticket/9240 ).