### PR TITLE
WIP*2: Add CUDA/cuDNN support

### DIFF
--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -29,7 +29,7 @@ cat << EOF | docker run -i \
                         -v ${RECIPE_ROOT}:/recipe_root \
                         -v ${FEEDSTOCK_ROOT}:/feedstock_root \
                         -a stdin -a stdout -a stderr \
-                        condaforge/linux-anvil \
+                        condaforge/linux-anvil-cudnn \
                         bash || exit $?
 
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,7 +10,7 @@ then
     # Stop Boost from using libquadmath.
     export CXXFLAGS="${CXXFLAGS} -DBOOST_MATH_DISABLE_FLOAT128"
 fi
-cmake -DCPU_ONLY=1 -DBLAS="open" -DCMAKE_INSTALL_PREFIX="${PREFIX}" ..
+cmake -DCPU_ONLY=0 -DUSE_CUDNN=1 -DBLAS="open" -DCMAKE_INSTALL_PREFIX="${PREFIX}" ..
 make
 make runtest
 make install


### PR DESCRIPTION
To solve this issue ( https://github.com/BVLC/caffe/issues/3578 ), it turns out we need to bump Boost to 1.61.\* to solve the underlying issue ( https://svn.boost.org/trac/boost/ticket/11852 ).

Also, it turns out we are blocked from getting this to work because this PR ( https://github.com/BVLC/caffe/pull/3919 ) is not merged and release yet.
