### PR TITLE
Add inspect linkages test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -108,6 +108,8 @@ test:
 
   imports:
     - caffe
+  commands:
+    - conda inspect linkages -n _test caffe  # [linux]
 
 about:
   home: http://caffe.berkeleyvision.org/


### PR DESCRIPTION
Ideally we should always run this test when there is a `cython` extension.