### PR TITLE
Follow the BLAS format specification

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,6 +2,8 @@
 {% set version_postfix = "rc3" %}
 {% set version = base_version + version_postfix %}
 
+{% set variant = "openblas" %}
+
 package:
   name: caffe
   version: {{ version }}
@@ -12,17 +14,17 @@ source:
   sha1: 79e075d06bea856164c926b92a40242b0369965b
 
 build:
-  number: 5
+  number: 200
   skip: true  # [not (linux and py27)]
   features:
-    - nomkl
+    - blas_{{ variant }}
 
 requirements:
   build:
     - cmake
     - cython
-    - nomkl
-    - openblas
+    - blas 1.1 {{ variant }}
+    - openblas 0.2.18*
     - boost 1.61.*
     - hdf5 1.8.17|1.8.17.*
     - gflags
@@ -50,8 +52,8 @@ requirements:
     - snappy
 
   run:
-    - nomkl
-    - openblas
+    - blas 1.1 {{ variant }}
+    - openblas 0.2.18*
     - boost 1.61.*
     - hdf5 1.8.17|1.8.17.*
     - gflags


### PR DESCRIPTION
Fixes https://github.com/conda-forge/caffe-feedstock/issues/7

This recipe proceeded the BLAS specification and tried to follow the model of `defaults` on Linux, which meant using OpenBLAS and using the `nomkl` feature. However, the `nomkl` strategy results in the problematic Accelerate Framework on OS X. So was not a tenable strategy there. Also Windows always built against `mkl`. There was never another option. We have been planning for OpenBLAS to be the cornerstone for everything that uses BLAS. At this point, it is exactly that. As a result, this recipe needs to be updated to follow the more modern guidelines that should enable cross-platform BLAS support. It should clear the way for OS X support relatively soon. Windows still needs some dependencies added before we can get it supported.