### PR TITLE
Upgrade to hdf5 1.8.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha1: afcb529881402b58733e00a66bf7ac6b7e969207
 
 build:
-  number: 200
+  number: 201
   skip: true  # [not (linux and py27)]
   features:
     - blas_{{ variant }}
@@ -26,7 +26,7 @@ requirements:
     - blas 1.1 {{ variant }}
     - openblas 0.2.19|0.2.19.*
     - boost 1.63.*
-    - hdf5 1.8.17|1.8.17.*
+    - hdf5 1.8.18|1.8.18.*
     - gflags
     - glog
     - h5py
@@ -55,7 +55,7 @@ requirements:
     - blas 1.1 {{ variant }}
     - openblas 0.2.19|0.2.19.*
     - boost 1.63.*
-    - hdf5 1.8.17|1.8.17.*
+    - hdf5 1.8.18|1.8.18.*
     - gflags
     - glog
     - h5py


### PR DESCRIPTION
A few CVEs were reported and fixed in hdf5 back in November 2016: http://blog.talosintelligence.com/2016/11/hdf5-vulns.html

The hdf5 release notes for that release are available here: https://support.hdfgroup.org/ftp/HDF5/current18/src/hdf5-1.8.18-RELEASE.txt

For additional info, please see: https://github.com/conda-forge/hdf5-feedstock/pull/68 and https://github.com/conda-forge/hdf5-feedstock/issues/71